### PR TITLE
Trigger test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,11 @@ add_library(avt_camera_nodelets
   src/frame_observer.cpp)
 add_dependencies_and_linkings(avt_camera_nodelets)
 
+
+add_executable(trigger_node src/nodes/trigger_node.cpp)
+add_dependencies_and_linkings(trigger_node)
+
+
 #############
 ## Install ##
 #############

--- a/cfg/AvtVimbaCamera.cfg
+++ b/cfg/AvtVimbaCamera.cfg
@@ -15,7 +15,8 @@ trigger_source_enum = gen.enum( [ gen.const("Freerun",   str_t, "Freerun",   "Ru
 				                gen.const("Line3",     str_t, "Line3",   "External trigger on SyncIn3 line"),
 				                gen.const("Line4",     str_t, "Line4",   "External trigger on SyncIn4 line"),
 												gen.const("FixedRate", str_t, "FixedRate",   "Camera self-triggers at a fixed frame rate defined by `~AcquisitionFrameRateAbs`"),
-				                gen.const("Software",  str_t, "Software",   "Software inititated image capture")], "Set Trigger Mode")
+				                gen.const("Software",  str_t, "Software",   "Software inititated image capture"),
+						gen.const("Action0" , str_t, "Action0", "Trigger over ethernet action0")], "Set Trigger Mode")
 trigger_activation_enum = gen.enum([ gen.const("RisingEdge",  str_t, "RisingEdge", ""),
 						      		 gen.const("FallingEdge", str_t, "FallingEdge", ""),
 						      		 gen.const("AnyEdge",     str_t, "AnyEdge", ""),
@@ -27,6 +28,10 @@ trigger_selector_enum = gen.enum([ gen.const("FrameStart",        str_t, "FrameS
 						      	   gen.const("AcquisitionStart",  str_t, "AcquisitionStart", ""),
 						      	   gen.const("AcquisitionEnd",    str_t, "AcquisitionEnd", ""),
 						      	   gen.const("AcquisitionRecord", str_t, "AcquisitionRecord", "")], "Trigger activation selector")
+action_selector_enum = gen.enum([ gen.const("ActionDeviceKey", str_t, "ActionDeviceKey", ""),
+                       gen.const("ActionGroupKey", str_t, "ActionGroupKey", ""),
+                       gen.const("ActionGroupMask", str_t, "ActionGroupMask", "")], "Action selection")
+
 acquisition_mode_enum = gen.enum( [ gen.const("Continuous",  str_t, "Continuous", "After an acquisition start event, the camera will continuously receive frame trigger events."),
 									gen.const("SingleFrame", str_t, "SingleFrame", "The camera will only deliver a single frame trigger event"),
 									gen.const("MultiFrame",  str_t, "MultiFrame", "The camera will acquire the number of images specified by `~AcquisitionFrameCount`. Further trigger events will be ignored"),
@@ -110,6 +115,9 @@ gen.add("trigger_mode",			    str_t,    SensorLevels.RECONFIGURE_STOP,    "Camer
 gen.add("trigger_selector",     str_t,    SensorLevels.RECONFIGURE_STOP,    "Camera trigger selector", "FrameStart", edit_method = trigger_selector_enum)
 gen.add("trigger_activation",   str_t,    SensorLevels.RECONFIGURE_STOP,    "Camera trigger activation", "RisingEdge", edit_method = trigger_activation_enum)
 gen.add("trigger_delay",   		  double_t, SensorLevels.RECONFIGURE_RUNNING, "Trigger delay in us (only valid when set to external trigger)", 0.0, 0.0, 60000000.0)
+gen.add("action_device_key",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action device key", 1, 1, 4294967295)
+gen.add("action_group_key",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action group key", 1, 1, 4294967295)
+gen.add("action_group_mask",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action group mask", 1, 1, 4294967295)
 # EXPOSURE
 gen.add("exposure",             double_t, SensorLevels.RECONFIGURE_RUNNING, "Camera exposure time in microseconds.", 50000, 41, 60000000)
 gen.add("exposure_auto",        str_t,    SensorLevels.RECONFIGURE_RUNNING, "Sets the camera exposure. If continously automatic, causes the `~exposure` setting to be ignored.", "Continuous", edit_method = auto_enum)

--- a/cfg/AvtVimbaCameraStereo.cfg
+++ b/cfg/AvtVimbaCameraStereo.cfg
@@ -15,7 +15,8 @@ trigger_source_enum = gen.enum( [ gen.const("Freerun",   str_t, "Freerun",   "Ru
                         gen.const("Line3",     str_t, "Line3",   "External trigger on SyncIn3 line"),
                         gen.const("Line4",     str_t, "Line4",   "External trigger on SyncIn4 line"),
                         gen.const("FixedRate", str_t, "FixedRate",   "Camera self-triggers at a fixed frame rate defined by `~AcquisitionFrameRateAbs`"),
-                        gen.const("Software",  str_t, "Software",   "Software inititated image capture")], "Set Trigger Mode")
+                        gen.const("Software",  str_t, "Software",   "Software inititated image capture"),
+ 			gen.const("Action0",  str_t, "Action0",   "Software trigger via Action command 0")], "Set Tigger Mode")
 trigger_activation_enum = gen.enum([ gen.const("RisingEdge",  str_t, "RisingEdge", ""),
                        gen.const("FallingEdge", str_t, "FallingEdge", ""),
                        gen.const("AnyEdge",     str_t, "AnyEdge", ""),
@@ -27,6 +28,9 @@ trigger_selector_enum = gen.enum([ gen.const("FrameStart",        str_t, "FrameS
                        gen.const("AcquisitionStart",  str_t, "AcquisitionStart", ""),
                        gen.const("AcquisitionEnd",    str_t, "AcquisitionEnd", ""),
                        gen.const("AcquisitionRecord", str_t, "AcquisitionRecord", "")], "Trigger activation selector")
+action_selector_enum = gen.enum([ gen.const("ActionDeviceKey", str_t, "ActionDeviceKey", ""),
+		       gen.const("ActionGroupKey", str_t, "ActionGroupKey", ""),
+		       gen.const("ActionGroupMask", str_t, "ActionGroupMask", "")], "Action selection")
 acquisition_mode_enum = gen.enum( [ gen.const("Continuous",  str_t, "Continuous", "After an acquisition start event, the camera will continuously receive frame trigger events."),
                   gen.const("SingleFrame", str_t, "SingleFrame", "The camera will only deliver a single frame trigger event"),
                   gen.const("MultiFrame",  str_t, "MultiFrame", "The camera will acquire the number of images specified by `~AcquisitionFrameCount`. Further trigger events will be ignored"),
@@ -91,6 +95,10 @@ gen.add("left_trigger_mode",         str_t,    SensorLevels.RECONFIGURE_STOP,   
 gen.add("left_trigger_selector",     str_t,    SensorLevels.RECONFIGURE_STOP,    "Camera trigger selector", "FrameStart", edit_method = trigger_selector_enum)
 gen.add("left_trigger_activation",   str_t,    SensorLevels.RECONFIGURE_STOP,    "Camera trigger activation", "RisingEdge", edit_method = trigger_activation_enum)
 gen.add("left_trigger_delay",        double_t, SensorLevels.RECONFIGURE_RUNNING, "Trigger delay in us (only valid when set to external trigger)", 0.0, 0.0, 60000000.0)
+gen.add("left_action_device_key",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action device key", 1, 1, 4294967295)
+gen.add("left_action_group_key",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action group key", 1, 1, 4294967295)
+gen.add("left_action_group_mask",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action group mask", 1, 1, 4294967295)
+
 # PTP
 gen.add("left_ptp_mode",             str_t,    SensorLevels.RECONFIGURE_RUNNING,"Controls the PTP behaviour of the clock port.", "Off", edit_method=ptp_mode_enum)
 # GPIO
@@ -113,6 +121,10 @@ gen.add("right_trigger_mode",         str_t,    SensorLevels.RECONFIGURE_STOP,  
 gen.add("right_trigger_selector",     str_t,    SensorLevels.RECONFIGURE_STOP,    "Camera trigger selector", "FrameStart", edit_method = trigger_selector_enum)
 gen.add("right_trigger_activation",   str_t,    SensorLevels.RECONFIGURE_STOP,    "Camera trigger activation", "RisingEdge", edit_method = trigger_activation_enum)
 gen.add("right_trigger_delay",        double_t, SensorLevels.RECONFIGURE_RUNNING, "Trigger delay in us (only valid when set to external trigger)", 0.0, 0.0, 60000000.0)
+gen.add("right_action_device_key",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action device key", 1, 1, 4294967295)
+gen.add("right_action_group_key",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action group key", 1, 1, 4294967295)
+gen.add("right_action_group_mask",   int_t,    SensorLevels.RECONFIGURE_STOP,    "Camera action group mask", 1, 1, 4294967295)
+
 # PTP
 gen.add("right_ptp_mode",             str_t,    SensorLevels.RECONFIGURE_RUNNING,"Controls the PTP behaviour of the clock port.", "Off", edit_method=ptp_mode_enum)
 # GPIO

--- a/include/avt_vimba_camera/avt_vimba_camera.h
+++ b/include/avt_vimba_camera/avt_vimba_camera.h
@@ -61,7 +61,8 @@ enum FrameStartTriggerMode {
   SyncIn1,
   SyncIn2,
   SyncIn3,
-  SyncIn4
+  SyncIn4,
+  Action0
 };
 
 enum CameraState {

--- a/include/avt_vimba_camera/trigger_node.h
+++ b/include/avt_vimba_camera/trigger_node.h
@@ -1,0 +1,66 @@
+//#include <avt_vimba_camera/avt_vimba_camera.h>
+#include <VimbaC/Include/VimbaC.h>
+
+
+// struct representing an Action Command
+typedef struct tActionCommand
+{
+    VmbUint32_t     mDeviceKey;
+    VmbUint32_t     mGroupKey;
+    VmbUint32_t     mGroupMask;
+
+} tActionCommand;
+
+typedef enum tFeatureOwner
+{
+    eFeatureOwnerUnknown     = 0,
+    eFeatureOwnerSystem      = 1,
+    eFeatureOwnerInterface   = 2,
+    eFeatureOwnerCamera      = 3
+
+} tFeatureOwner;
+
+class cActionCommands
+{
+    private:
+        //VimbaSystem&    mSystem;
+        //InterfacePtr    mInterface;
+        //CameraPtr       mCamera;
+
+        //cFrameObserver* mFrameObserver;
+
+        bool            mSystemFlag;
+        bool            mInterfaceFlag;
+        bool            mCameraFlag;
+        bool            mStreamingFlag;
+
+    public:
+        //
+        // Constructor
+        //
+        cActionCommands();
+
+        //
+        // Destructor
+        //
+        ~cActionCommands();
+
+        //
+        // Helper method to read feature values of any type
+        //
+        // Parameters:
+	//
+};
+
+VmbErrorType GetFeatureValue( const char* aName, tFeatureOwner aOwner, VmbFeatureDataType* aType, void* aValue, size_t* aSize );
+
+VmbErrorType SetFeatureValue( const char* aName, tFeatureOwner aOwner, VmbFeatureDataType aType, void* aValue, size_t aSize );
+
+
+VmbError_t PrepareActionCommand( VmbHandle_t aHandle, tActionCommand* aCommand );
+
+VmbErrorType RunCommand( const char* aName, tFeatureOwner aOwner );
+
+void FailureShutdown();
+
+

--- a/launch/mono_camera.launch
+++ b/launch/mono_camera.launch
@@ -5,8 +5,8 @@
 	</group>
 
 	<node name="camera" pkg="avt_vimba_camera" type="mono_camera_node" output="screen">
-		<param name="guid" value="50-0503343290"/>
-		<param name="ip" value=""/>
+		<param name="guid" value="50-0536933821"/>
+		<param name="ip" value="172.16.154.175"/>
 		<param name="camera_info_url" value="file://$(find avt_vimba_camera)/calibrations/calibration_50-0503343290.yaml"/>
 		<param name="frame_id" value="left_optical"/>
 		<param name="trig_timestamp_topic" value=""/>
@@ -32,7 +32,7 @@
 		<param name="acquisition_mode" value="Continuous"/>
 
 		<!-- Acquisition rate in fps -->
-		<param name="acquisition_rate" value="12"/>
+		<param name="acquisition_rate" value="20"/>
 
 		<!-- Pixel format:
 			1. Mono8
@@ -44,31 +44,33 @@
 			7. RGB8Packed
 			8. BGR8Packed
 		-->
-		<param name="pixel_format" value="BayerRG8"/>
+		<param name="pixel_format" value="Mono8"/>
 		<!-- Exposure in us -->
-		<param name="exposure" value="1000"/>
+		<param name="exposure" value="5000"/>
 		<!-- Gain in dB -->
-		<param name="gain" value="0"/>
+		<param name="gain" value="20"/>
 
 		<!-- Auto control
 			1. Off
 			2. Once
 			3. Continuous
 		-->
-		<param name="exposure_auto" value="Continuous"/>
-		<param name="gain_auto" value="Continuous"/>
-		<param name="whitebalance_auto" value="Continuous"/>
+		<param name="exposure_auto" value="Off"/>
+		<param name="exposure_auto_target" value="20"/>
+		<param name="exposure_auto_max" value="10000"/>
+		<param name="gain_auto" value="Off"/>
+		<param name="whitebalance_auto" value="Off"/>
 
-		<param name="binning_x" value="1"/>
+		<param name="binning_x" value="2"/>
 		<param name="binning_y" value="1"/>
 		<param name="decimation_x" value="1"/>
-		<param name="decimation_y" value="1"/>
-		<param name="x_offset" value="8"/>
-		<param name="y_offset" value="9"/>
-		<param name="width" value="1920"/>
-		<param name="height" value="1440"/>
+		<param name="decimation_y" value="2"/>
+		<param name="x_offset" value="0"/>
+		<param name="y_offset" value="0"/>
+		<param name="width" value="2464"/>
+		<param name="height" value="2056"/>
 
-		<param name="stream_bytes_per_second" value="45000000"/>
+		<param name="stream_bytes_per_second" value="115000000"/>
 	</node>
 
 </launch>

--- a/launch/mono_camera_nodelet.launch
+++ b/launch/mono_camera_nodelet.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="name" default="camera" doc="The name of the camera"/>
-  <arg name="ip" default="" doc="The IP for the camera to connect to"/>
-  <arg name="guid" default="50-0503343290" doc="The GUID for the camera to connect to"/>
+  <arg name="ip" default="172.16.154.175" doc="The IP for the camera to connect to"/>
+  <arg name="guid" default="50-0536933821" doc="The GUID for the camera to connect to"/>
   <arg name="frame_id" default="left_optical" doc="The frame id of the camera"/>
   <arg name="image_proc" default="false"/>
 
@@ -27,22 +27,22 @@
       <param name="acquisition_rate" value="12"/>
       <param name="pixel_format" value="BayerRG8"/>
       <!-- Exposure in us -->
-      <param name="exposure" value="1000"/>
+      <param name="exposure" value="10000"/>
       <!-- Gain in dB -->
-      <param name="gain" value="0"/>
+      <param name="gain" value="10"/>
       <param name="exposure_auto" value="Continuous"/>
-      <param name="gain_auto" value="Continuous"/>
-      <param name="whitebalance_auto" value="Continuous"/>
+      <param name="gain_auto" value="Off"/>
+      <param name="whitebalance_auto" value="Off"/>
 
       <param name="binning_x" value="1"/>
       <param name="binning_y" value="1"/>
       <param name="decimation_x" value="1"/>
       <param name="decimation_y" value="1"/>
-      <param name="x_offset" value="8"/>
-      <param name="y_offset" value="9"/>
-      <param name="width" value="1920"/>
-      <param name="height" value="1440"/>
+      <param name="x_offset" value="0"/>
+      <param name="y_offset" value="0"/>
+      <param name="width" value="2464"/>
+      <param name="height" value="2056"/>
 
-      <param name="stream_bytes_per_second" value="45000000"/>
+      <param name="stream_bytes_per_second" value="115000000"/>
   </node>
 </launch>

--- a/launch/stereo_camera_one_node.launch
+++ b/launch/stereo_camera_one_node.launch
@@ -1,7 +1,7 @@
 <launch>
 	<arg name="stereo" default="stereo"/>
-	<arg name="left_guid" default="50-0503343289"/>
-	<arg name="right_guid" default="50-0503343290"/>
+	<arg name="left_guid" default="50-0536891657"/>
+	<arg name="right_guid" default="50-0536933821"/>
 	
   	<node ns="$(arg stereo)" name="stereo_image_proc" pkg="stereo_image_proc" type="stereo_image_proc" output="screen"/>
 
@@ -9,7 +9,10 @@
 
 		<!-- Static params -->
 		<param name="left_guid" value="$(arg left_guid)"/>
+                <param name="left_ip" value="$(arg left_guid)"/>
 		<param name="right_guid" value="$(arg right_guid)"/>
+                <param name="right_ip" value="$(arg left_guid)"/>
+
 		<param name="left_camera_info_url" value="file://$(find avt_vimba_camera)/calibrations/calibration_$(arg left_guid).yaml"/>
 		<param name="right_camera_info_url" value="file://$(find avt_vimba_camera)/calibrations/calibration_$(arg right_guid).yaml"/>
 

--- a/launch/stereo_camera_two_nodes.launch
+++ b/launch/stereo_camera_two_nodes.launch
@@ -44,12 +44,12 @@
 			<param name="width" value="2464"/>
 			<param name="height" value="2056"/>
 			<param name="ptp_mode" value="Master"/>
-			<param name="stream_bytes_per_second" value="50000000"/>
+			<param name="stream_bytes_per_second" value="60000000"/>
 		</node>
 
 		<node name="right" pkg="avt_vimba_camera" type="mono_camera_node" output="screen">
-			<param name="guid" value="50-0536933821"/>
-			<param name="ip_address" value="172.16.154.175"/>
+			<param name="guid" value="50-0536898946"/>
+			<param name="ip_address" value="172.16.154.166"/>
 			<param name="camera_info_url" value="file://$(find avt_vimba_camera)/calibrations/calibration_50-0503343290.yaml"/>
 			<param name="frame_id" value="right_optical"/>
 			<param name="trig_timestamp_topic" value=""/>

--- a/launch/stereo_camera_two_nodes.launch
+++ b/launch/stereo_camera_two_nodes.launch
@@ -13,50 +13,71 @@
 
 
 		<node name="left" pkg="avt_vimba_camera" type="mono_camera_node" output="screen">
-			<param name="guid" value="50-0503343289"/>
-			<param name="ip_address" value=""/>
+			<param name="guid" value="50-0536891657"/>
+			<param name="ip_address" value="172.16.154.165"/>
 			<param name="camera_info_url" value="file://$(find avt_vimba_camera)/calibrations/calibration_50-0503343289.yaml"/>
 			<param name="frame_id" value="left_optical"/>
 			<param name="trig_timestamp_topic" value=""/>
-			<param name="trigger_source" value="FixedRate"/>
+			<param name="trigger_source" value="Action0"/>
+                        <param name="trigger_mode" value="On"/>
+                        <param name="action_device_key" value="1"/>
+                        <param name="action_group_key" value="1"/>
+                        <param name="action_group_mask" value="1"/>
+                        <param name="trigger_selector" value="FrameStart"/>
 			<!--param name="sync_out_source" value="Acquiring"/-->
 			<param name="sync_out_source" value="Exposing"/>
 			<param name="sync_out_polarity" value="Normal"/>
 			<param name="acquisition_mode" value="Continuous"/>
-			<param name="acquisition_rate" value="10"/>
+			<param name="acquisition_rate" value="1"/>
 			<param name="pixel_format" value="BayerRG8"/>
-			<param name="auto_exposure" value="Auto"/>
-			<param name="auto_gain" value="Auto"/>
-			<param name="auto_whitebalance" value="Auto"/>
-			<param name="x_offset" value="8"/>
-			<param name="y_offset" value="9"/>
-			<param name="width" value="1920"/>
-			<param name="height" value="1440"/>
+			<param name="auto_exposure" value="Off"/>
+                        <param name="exposure" value="5000"/>
+			<param name="auto_gain" value="Off"/>
+                        <param name="gain" value="20"/>
+			<param name="auto_whitebalance" value="Off"/>
+                        <param name="binning_x" value="2"/>
+                        <param name="binning_y" value="1"/>
+                        <param name="decimation_x" value="1"/>
+                        <param name="decimation_y" value="2"/>
+			<param name="x_offset" value="1"/>
+			<param name="y_offset" value="1"/>
+			<param name="width" value="2464"/>
+			<param name="height" value="2056"/>
 			<param name="ptp_mode" value="Master"/>
-			<param name="stream_bytes_per_second" value="45000000"/>
+			<param name="stream_bytes_per_second" value="50000000"/>
 		</node>
 
 		<node name="right" pkg="avt_vimba_camera" type="mono_camera_node" output="screen">
-			<param name="guid" value="50-0503343290"/>
-			<param name="ip_address" value=""/>
+			<param name="guid" value="50-0536933821"/>
+			<param name="ip_address" value="172.16.154.175"/>
 			<param name="camera_info_url" value="file://$(find avt_vimba_camera)/calibrations/calibration_50-0503343290.yaml"/>
 			<param name="frame_id" value="right_optical"/>
 			<param name="trig_timestamp_topic" value=""/>
-			<param name="trigger_source" value="Line1"/>
-			<param name="trigger_selector" value="AcquisitionStart"/>
+			<param name="trigger_source" value="Action0"/>
+			<param name="trigger_selector" value="FrameStart"/>
 			<param name="trigger_mode" value="On"/>
+                        <param name="action_device_key" value="1"/>
+                        <param name="action_group_key" value="1"/>
+                        <param name="action_group_mask" value="1"/>
+                        <param name="acquisition_rate" value="1"/>
 			<param name="sync_in_selector" value="SyncIn1"/>
 			<param name="acquisition_mode" value="Continuous"/>
 			<param name="pixel_format" value="BayerRG8"/>
-			<param name="auto_exposure" value="Auto"/>
-			<param name="auto_gain" value="Auto"/>
-			<param name="auto_whitebalance" value="Auto"/>
-			<param name="x_offset" value="8"/>
-			<param name="y_offset" value="9"/>
-			<param name="width" value="1920"/>
-			<param name="height" value="1440"/>
+                        <param name="auto_exposure" value="Off"/>
+                        <param name="exposure" value="5000"/>
+                        <param name="auto_gain" value="Off"/>
+                        <param name="gain" value="20"/>
+                        <param name="auto_whitebalance" value="Off"/>
+                        <param name="binning_x" value="2"/>
+                        <param name="binning_y" value="1"/>
+                        <param name="decimation_x" value="1"/>
+                        <param name="decimation_y" value="2"/>
+			<param name="x_offset" value="1"/>
+			<param name="y_offset" value="1"/>
+			<param name="width" value="2464"/>
+			<param name="height" value="2056"/>
 			<param name="ptp_mode" value="Slave"/>
-			<param name="stream_bytes_per_second" value="45000000"/>
+			<param name="stream_bytes_per_second" value="50000000"/>
 		</node>
 	</group>
 </launch>

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -51,7 +51,8 @@ static const char* TriggerMode[] = {
   "Line1",
   "Line2",
   "Line3",
-  "Line4" };
+  "Line4",
+  "Action0"};
 static const char* AcquisitionMode[] = {
   "Continuous",
   "SingleFrame",
@@ -184,6 +185,7 @@ void AvtVimbaCamera::start(std::string ip_str, std::string guid_str, bool debug_
   vimba_camera_ptr_->GetInterfaceType(cam_int_type);
   if ( cam_int_type == VmbInterfaceEthernet ){
     runCommand("GVSPAdjustPacketSize");
+
   }
 
   std::string trigger_source;
@@ -192,7 +194,8 @@ void AvtVimbaCamera::start(std::string ip_str, std::string guid_str, bool debug_
 
   if (trigger_source_int == Freerun   ||
       trigger_source_int == FixedRate ||
-      trigger_source_int == SyncIn1) {
+      trigger_source_int == SyncIn1   ||
+      trigger_source_int == Action0) {
     // Create a frame observer for this camera
     SP_SET(frame_obs_ptr_, new FrameObserver(vimba_camera_ptr_,
       boost::bind(&avt_vimba_camera::AvtVimbaCamera::frameCallback, this, _1)));
@@ -658,6 +661,8 @@ int AvtVimbaCamera::getTriggerModeInt(std::string mode_str) {
     mode = SyncIn3;
   } else if (mode_str == TriggerMode[SyncIn4]) {
     mode = SyncIn4;
+  } else if (mode_str == TriggerMode[Action0]) {
+    mode = Action0;
   }
   return mode;
 }
@@ -840,6 +845,18 @@ void AvtVimbaCamera::updateAcquisitionConfig(Config& config) {
   if (config.trigger_delay != config_.trigger_delay || on_init_) {
     changed = true;
     setFeatureValue("TriggerDelayAbs", config.trigger_delay);
+  }
+  if (config.action_device_key != config_.action_device_key || on_init_) {
+    changed = true;
+    setFeatureValue("ActionDeviceKey", config.action_device_key);
+  }
+  if (config.action_group_key != config_.action_group_key || on_init_) {
+    changed = true;
+    setFeatureValue("ActionGroupKey", config.action_group_key);
+  }
+  if (config.action_group_mask != config_.action_group_mask || on_init_) {
+    changed = true;
+    setFeatureValue("ActionGroupMask", config.action_group_mask);
   }
   if(changed && show_debug_prints_){
     ROS_INFO_STREAM("New Acquisition and Trigger config (" << config.frame_id << ") : "

--- a/src/nodes/mono_camera_node.cpp
+++ b/src/nodes/mono_camera_node.cpp
@@ -9,6 +9,13 @@ int main(int argc, char** argv)
   ros::NodeHandle nhp("~");
 
   avt_vimba_camera::MonoCamera mc(nh,nhp);
+  
+  //ros::Rate r(25);
+  //while (1)
+  //{
+  //	  ros::spinOnce();
+  //	  r.sleep();
+  //}
 
   ros::spin();
   return 0;

--- a/src/nodes/trigger_node.cpp
+++ b/src/nodes/trigger_node.cpp
@@ -1,0 +1,104 @@
+#include "ros/ros.h"
+#include "std_msgs/String.h"
+#include <avt_vimba_camera/trigger_node.h>
+#include <VimbaC/Include/VimbaC.h>
+
+#include <sstream>
+#include <stdio.h>
+#include <stdlib.h>
+
+
+
+VmbError_t lError = VmbErrorSuccess;
+tActionCommand aCommand;
+int triggerFreq = 1;
+
+int main(int argc, char **argv)
+{
+
+	ros::init(argc, argv, "trigger_node");
+
+	ros::NodeHandle nh;
+	
+	VmbStartup();
+
+	aCommand.mDeviceKey = 1;
+	aCommand.mGroupKey = 1;
+	aCommand.mGroupMask = 1;
+
+	lError = PrepareActionCommand( gVimbaHandle, &aCommand );
+
+	if(argc > 0){
+		//sscanf(argv[1], "%d", &triggerFreq);
+		triggerFreq = atoi(argv[1]);
+	}
+
+
+	ros::Rate loop_rate(triggerFreq);
+
+	while (ros::ok())
+	{
+		if( VmbErrorSuccess == lError )
+            	{
+                	// send Action Command by calling command feature
+                	lError = PrepareActionCommand( gVimbaHandle, &aCommand );
+
+			//lError = RunCommand( "ActionCommand", eFeatureOwnerSystem );
+                	//runCommand("ActionCommand")
+			lError = VmbFeatureCommandRun( gVimbaHandle, "ActionCommand" );
+
+			if( VmbErrorSuccess != lError )
+			{
+				return 0;
+			}
+		}
+		loop_rate.sleep();
+		//printf("time: %f \n", loop_rate.cycleTime().toSec());
+	}
+
+	return 0;
+}
+
+VmbError_t PrepareActionCommand( VmbHandle_t aHandle, tActionCommand* aCommand )
+{
+    VmbError_t lError = VmbErrorSuccess;
+
+    // check parameter
+    if( (NULL == aHandle) || (NULL == aCommand) )
+    {
+        printf( "[F]...Invalid parameter given.\n" );
+        return VmbErrorBadParameter;
+    }
+
+    // set device key
+    lError = VmbFeatureIntSet( aHandle, "ActionDeviceKey", aCommand->mDeviceKey );
+    if( VmbErrorSuccess != lError )
+    {
+        printf( "[F]...Could not set ActionDeviceKey. Reason: %i\n", lError );
+        //FailureShutdown( aHandle );
+        //return lError;
+    }
+    // set group key
+    lError = VmbFeatureIntSet( aHandle, "ActionGroupKey", aCommand->mGroupKey );
+    if( VmbErrorSuccess != lError )
+    {
+        printf( "[F]...Could not set ActionGroupKey. Reason: %i\n", lError );
+        //FailureShutdown( aHandle );
+        //return lError;
+    }
+
+    // set group mask
+    lError = VmbFeatureIntSet( aHandle, "ActionGroupMask", aCommand->mGroupMask );
+    if( VmbErrorSuccess != lError )
+    {
+        printf( "[F]...Could not set ActionGroupMask. Reason: %i\n", lError );
+        //FailureShutdown( aHandle );
+        //return lError;
+    }
+
+    printf( "......Action Command has been set (%i,%i,%i)\n", aCommand->mDeviceKey, aCommand->mGroupKey, aCommand->mGroupMask );
+
+    return lError;
+}
+
+

--- a/src/stereo_camera.cpp
+++ b/src/stereo_camera.cpp
@@ -273,6 +273,9 @@ void StereoCamera::copyConfig(StereoConfig& sc, Config& lc, Config& rc) {
   lc.trigger_selector = sc.left_trigger_selector;
   lc.trigger_activation = sc.left_trigger_activation;
   lc.trigger_delay = sc.left_trigger_delay;
+  lc.action_device_key = sc.left_action_device_key;
+  lc.action_group_key = sc.left_action_group_key;
+  lc.action_group_mask = sc.left_action_group_mask;
   lc.exposure = sc.exposure;
   lc.exposure_auto = sc.exposure_auto;
   lc.exposure_auto_alg = sc.exposure_auto_alg;
@@ -322,6 +325,9 @@ void StereoCamera::copyConfig(StereoConfig& sc, Config& lc, Config& rc) {
   rc.trigger_selector = sc.right_trigger_selector;
   rc.trigger_activation = sc.right_trigger_activation;
   rc.trigger_delay = sc.right_trigger_delay;
+  rc.action_device_key = sc.right_action_device_key;
+  rc.action_group_key = sc.right_action_group_key;
+  rc.action_group_mask = sc.right_action_group_mask;
   rc.exposure = sc.exposure;
   rc.exposure_auto = sc.exposure_auto;
   rc.exposure_auto_alg = sc.exposure_auto_alg;


### PR DESCRIPTION
Initial implementation for trigger over ethernet with action commands. Enables synchronisation of multiple cameras using only a single cable.
Test Instructions:
-Set camera trigger_source to Action0 with action keys and masks all set to 1 (see stereo_camera_two_nodes.launch for an example)
-Run the trigger_node using 'rosrun trigger_node x' where x is the desired trigger frequency in Hz, eg 20
-Test the frequency of the incoming frames using 'rostopic hz'
-For a rough test of synchronisation for a stereo pair, a stopwatch on a phone can be held in front of the cameras and corresponding image pairs compared