### PR TITLE
Fix to the 'escalating to SIGTERM' issue when closing the application

### DIFF
--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -123,8 +123,6 @@ AvtVimbaCamera::AvtVimbaCamera(std::string name) {
   show_debug_prints_ = false;
   name_ = name;
 
-  signal(SIGINT, intHandler);
-
   camera_state_ = OPENING;
 
   updater_.setHardwareID("unknown");
@@ -309,6 +307,9 @@ CameraPtr AvtVimbaCamera::openCamera(std::string id_str) {
   CameraPtr camera;
   VimbaSystem& vimba_system(VimbaSystem::GetInstance());
 
+  // set handler to catch ctrl+c presses
+  sighandler_t oldHandler = signal(SIGINT, intHandler);
+
   // get camera
   VmbErrorType err = vimba_system.GetCameraByID(id_str.c_str(), camera);
   while (err != VmbErrorSuccess) {
@@ -340,6 +341,9 @@ CameraPtr AvtVimbaCamera::openCamera(std::string id_str) {
       return camera;
     }
   }
+
+  // set previous handler back
+  signal(SIGINT, oldHandler);
 
   std::string cam_id, cam_name, cam_model, cam_sn, cam_int_id;
   VmbInterfaceType cam_int_type;


### PR DESCRIPTION
The goal of this PR is to fix the following issue: https://github.com/astuff/avt_vimba_camera/issues/19.

The issue was actually coming from the signal handler for the SIGINT event, which initial goal was to cancel the search for a camera if it couldn't be found.
However, the main issue here was that, even if a camera was found, this signal handler would remain activated, and thus would catch our ctrl+C presses when trying to exit the application, and therefore would only change the value of the `keepRunning` variable instead of exiting.

The fix proposed here is to make this signal handler only enabled for the few lines where it is needed, by re-enabling the default one just after.
This was tested with success with a Mako G-192C camera: the application correctly exits now without ROS escalating to SIGTERM, both while the camera is running and while it is not being found.