### PR TITLE
Added features required to run USB cameras

### DIFF
--- a/cfg/AvtVimbaCamera.cfg
+++ b/cfg/AvtVimbaCamera.cfg
@@ -11,9 +11,10 @@ gen = ParameterGenerator()
 
 trigger_source_enum = gen.enum([
   gen.const("Freerun",   str_t, "Freerun",   "Run at maximum frame rate"),
-  gen.const("Line1",     str_t, "Line1",     "External trigger on SyncIn1 line"),
-  gen.const("Line2",     str_t, "Line2",     "External trigger on SyncIn2 line"),
-  gen.const("Line3",     str_t, "Line3",     "External trigger on SyncIn3 line"),
+  gen.const("Line0",     str_t, "Line0",     "External trigger on SyncIn0/Line0 line"),
+  gen.const("Line1",     str_t, "Line1",     "External trigger on SyncIn1/Line1 line"),
+  gen.const("Line2",     str_t, "Line2",     "External trigger on SyncIn2/Line2 line"),
+  gen.const("Line3",     str_t, "Line3",     "External trigger on SyncIn3/Line3 line"),
   gen.const("Line4",     str_t, "Line4",     "External trigger on SyncIn4 line"),
   gen.const("FixedRate", str_t, "FixedRate", "Camera self-triggers at a fixed frame rate defined by `~AcquisitionFrameRateAbs`"),
   gen.const("Software",  str_t, "Software",  "Software inititated image capture"),
@@ -129,6 +130,18 @@ sync_source_enum = gen.enum([
   gen.const("LineIn2",                 str_t, "LineIn2", "")
 ],"Sync-out signal")
 
+line_selector_enum = gen.enum([
+  gen.const("USBLine0",  str_t, "Line0", ""),
+  gen.const("USBLine1",  str_t, "Line1", ""),
+  gen.const("USBLine2",  str_t, "Line2", ""),
+  gen.const("USBLine3",  str_t, "Line3", ""),
+],"Line selector")
+
+line_mode_enum = gen.enum([
+  gen.const("Output", str_t, "Output", ""),
+  gen.const("Input",  str_t, "Input", "")
+],"Line mode")
+
 exposure_alg_enum = gen.enum([
   gen.const("Mean", str_t, "Mean", "[Default] The arithmetic mean of the histogram of the current image is compared to ExposureAutoTarget, and the next image adjusted in exposure time to meet this target. Bright areas are allowed to saturate"),
   gen.const("FitRange", str_t, "FitRange", "The histogram of the current image is measured, and the exposure time of the next image is adjusted so bright areas are not saturated")
@@ -192,11 +205,14 @@ gen.add("pixel_format",           str_t,    SensorLevels.RECONFIGURE_CLOSE,   "F
 gen.add("stream_bytes_per_second",int_t,    SensorLevels.RECONFIGURE_RUNNING, "Limits the data rate of the camera.", 124000000, 1, 125000000)
 # PTP
 gen.add("ptp_mode",               str_t,    SensorLevels.RECONFIGURE_RUNNING, "Controls the PTP behavior of the clock port.", "Off", edit_method=ptp_mode_enum)
-# GPIO
+# GIGE GPIO
 gen.add("sync_in_selector",       str_t,    SensorLevels.RECONFIGURE_STOP,    "Selects the sync-out line to control", "SyncIn1", edit_method=sync_in_selector_enum)
 gen.add("sync_out_polarity",      str_t,    SensorLevels.RECONFIGURE_STOP,    "Polarity applied to the sync-out line specified by `sync_out_selector`",  "Normal", edit_method=polarity_enum)
 gen.add("sync_out_selector",      str_t,    SensorLevels.RECONFIGURE_STOP,    "Selects the sync-out line to control", "SyncOut1", edit_method=sync_out_selector_enum)
 gen.add("sync_out_source",        str_t,    SensorLevels.RECONFIGURE_STOP,    "Signal source of the sync-out line specified by `sync_out_selector`", "GPO", edit_method=sync_source_enum)
+# USB GPIO
+gen.add("line_selector",          str_t,    SensorLevels.RECONFIGURE_STOP,    "Selects the line to control", "Line0", edit_method=line_selector_enum)
+gen.add("line_mode",              str_t,    SensorLevels.RECONFIGURE_STOP,    "Controls the mode of the line specified by `line_selector`", "Input", edit_method=line_mode_enum)
 # IRIS
 gen.add("iris_auto_target",       int_t,    SensorLevels.RECONFIGURE_RUNNING, "This is the target image mean value, in percent.", 50, 0, 100)
 gen.add("iris_mode",              str_t,    SensorLevels.RECONFIGURE_RUNNING, "Set the iris mode. Disabled: no iris control. Video: enable video iris. VideoOpen: fully open a video iris. VideoClose: fully close a video iris.",  "Continuous", edit_method = auto_enum)

--- a/include/avt_vimba_camera/avt_vimba_camera.h
+++ b/include/avt_vimba_camera/avt_vimba_camera.h
@@ -57,6 +57,7 @@ enum FrameStartTriggerMode
   Freerun,
   FixedRate,
   Software,
+  SyncIn0,
   SyncIn1,
   SyncIn2,
   SyncIn3,
@@ -166,6 +167,7 @@ private:
   void updatePixelFormatConfig(Config& config);
   void updatePtpModeConfig(Config& config);
   void updateGPIOConfig(Config& config);
+  void updateUSBGPIOConfig(Config& config);
   void updateIrisConfig(Config& config);
 
   void getCurrentState(diagnostic_updater::DiagnosticStatusWrapper& stat);

--- a/launch/mono_camera.launch
+++ b/launch/mono_camera.launch
@@ -69,6 +69,9 @@
   <arg name="sync_out_polarity" default="Normal"/>
   <arg name="sync_out_selector" default="SyncOut1"/>
   <arg name="sync_out_source" default="GPO"/>
+  <!-- USB GPIO -->
+  <arg name="line_selector" default="Line0"/>
+  <arg name="line_mode" default="Input"/>
   <!-- Iris -->
   <arg name="iris_auto_target" default="50"/>
   <arg name="iris_mode" default="Continuous"/>
@@ -142,6 +145,9 @@
     <param name="sync_out_polarity" value="$(arg sync_out_polarity)"/>
     <param name="sync_out_selector" value="$(arg sync_out_selector)"/>
     <param name="sync_out_source" value="$(arg sync_out_source)"/>
+
+    <param name="line_selector" value="$(arg line_selector)"/>
+    <param name="line_mode" value="$(arg line_mode)"/>
 
     <param name="iris_auto_target" value="$(arg iris_auto_target)"/>
     <param name="iris_mode" value="$(arg iris_mode)"/>

--- a/launch/mono_camera_nodelet.launch
+++ b/launch/mono_camera_nodelet.launch
@@ -66,6 +66,9 @@
   <arg name="sync_out_polarity" default="Normal"/>
   <arg name="sync_out_selector" default="SyncOut1"/>
   <arg name="sync_out_source" default="GPO"/>
+  <!-- USB GPIO -->
+  <arg name="line_selector" default="Line0"/>
+  <arg name="line_mode" default="Input"/>
   <!-- Iris -->
   <arg name="iris_auto_target" default="50"/>
   <arg name="iris_mode" default="Continuous"/>
@@ -142,6 +145,9 @@
     <param name="sync_out_polarity" value="$(arg sync_out_polarity)"/>
     <param name="sync_out_selector" value="$(arg sync_out_selector)"/>
     <param name="sync_out_source" value="$(arg sync_out_source)"/>
+
+    <param name="line_selector" value="$(arg line_selector)"/>
+    <param name="line_mode" value="$(arg line_mode)"/>
 
     <param name="iris_auto_target" value="$(arg iris_auto_target)"/>
     <param name="iris_mode" value="$(arg iris_mode)"/>

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -41,7 +41,7 @@
 namespace avt_vimba_camera
 {
 static const char* AutoMode[] = { "Off", "Once", "Continuous" };
-static const char* TriggerMode[] = { "Freerun", "FixedRate", "Software", "Line1",  "Line2",
+static const char* TriggerMode[] = { "Freerun", "FixedRate", "Software", "Line0", "Line1",  "Line2",
                                      "Line3",   "Line4",     "Action0",  "Action1" };
 static const char* AcquisitionMode[] = { "Continuous", "SingleFrame", "MultiFrame", "Recorder" };
 static const char* PixelFormatMode[] = { "Mono8",           "Mono10",          "Mono10Packed",    "Mono12",
@@ -155,7 +155,7 @@ void AvtVimbaCamera::start(const std::string& ip_str, const std::string& guid_st
   int trigger_source_int = getTriggerModeInt(trigger_source);
 
   if (trigger_source_int == Freerun || trigger_source_int == FixedRate || trigger_source_int == SyncIn1 ||
-      trigger_source_int == Action0 || trigger_source_int == Action1)
+      trigger_source_int == Action0 || trigger_source_int == Action1 || trigger_source_int == Software)
   {
     // Create a frame observer for this camera
     SP_SET(frame_obs_ptr_,
@@ -667,6 +667,10 @@ int AvtVimbaCamera::getTriggerModeInt(std::string mode_str)
   {
     mode = Software;
   }
+  else if (mode_str == TriggerMode[SyncIn0])
+  {
+    mode = SyncIn0;;
+  }
   else if (mode_str == TriggerMode[SyncIn1])
   {
     mode = SyncIn1;
@@ -857,6 +861,7 @@ void AvtVimbaCamera::updateConfig(Config& config)
   updateROIConfig(config);
   updateBandwidthConfig(config);
   updateGPIOConfig(config);
+  updateUSBGPIOConfig(config);
   updatePtpModeConfig(config);
   updatePixelFormatConfig(config);
   updateAcquisitionConfig(config);
@@ -1169,7 +1174,7 @@ void AvtVimbaCamera::updatePixelFormatConfig(Config& config)
   }
 }
 
-/** Change the GPIO configuration */
+/** Change the Gige GPIO configuration */
 void AvtVimbaCamera::updateGPIOConfig(Config& config)
 {
   if (on_init_)
@@ -1191,6 +1196,23 @@ void AvtVimbaCamera::updateGPIOConfig(Config& config)
   if (config.sync_out_source != config_.sync_out_source || on_init_)
   {
     configureFeature("SyncOutSource", config.sync_out_source, config.sync_out_source);
+  }
+}
+
+/** Change the USB GPIO configuration */
+void AvtVimbaCamera::updateUSBGPIOConfig(Config& config)
+{
+  if (on_init_)
+  {
+    ROS_INFO("Updating USB GPIO config:");
+  }
+  if (config.line_selector != config_.line_selector|| on_init_)
+  {
+    configureFeature("LineSelector", config.line_selector, config.line_selector);
+  }
+  if (config.line_mode != config_.line_mode || on_init_)
+  {
+    configureFeature("LineMode", config.line_mode, config.line_mode);
   }
 }
 


### PR DESCRIPTION
In this PR support for the following features were added: "LineSelector" and "LineMode". These features are required for configuring USB cameras. 