### PR TITLE
add start/stop srvs and example config for usb cameras

### DIFF
--- a/config/usb_1800_U.yaml
+++ b/config/usb_1800_U.yaml
@@ -1,0 +1,15 @@
+/**:
+  ros__parameters:
+    feature/AcquisitionFrameCount: 1
+    feature/AcquisitionMode: Continuous
+    feature/BalanceWhiteAuto: Continuous
+    feature/ExposureTime: 100000.0
+    feature/GainAuto: Continuous
+    feature/PixelFormat: Mono8
+    feature/TriggerActivation: RisingEdge
+    feature/TriggerMode: 'Off'
+    feature/TriggerSelector: AcquisitionStart
+    feature/TriggerSource: Software
+    feature/Width: 4024
+    feature/Height: 3036
+    feature/LineMode: Input

--- a/include/avt_vimba_camera/avt_vimba_camera.hpp
+++ b/include/avt_vimba_camera/avt_vimba_camera.hpp
@@ -88,6 +88,7 @@ public:
   }
 
   // Getters
+  CameraState getCameraState();
   double getTimestamp();
   double getDeviceTemp();
   int getImageWidth();
@@ -102,6 +103,10 @@ public:
   void setCallback(frameCallbackFunc callback)
   {
     userFrameCallback = callback;
+  }
+  void setForceStop(bool force_stop)
+  {
+    force_stopped_ = force_stop;
   }
 
 private:
@@ -124,6 +129,7 @@ private:
   CameraState camera_state_;
   bool opened_;
   bool streaming_;
+  bool force_stopped_;
   bool on_init_;
   bool on_init_config_;
   std::string guid_;

--- a/include/avt_vimba_camera/avt_vimba_camera.hpp
+++ b/include/avt_vimba_camera/avt_vimba_camera.hpp
@@ -88,7 +88,7 @@ public:
   }
 
   // Getters
-  CameraState getCameraState();
+  CameraState getCameraState() const;
   double getTimestamp();
   double getDeviceTemp();
   int getImageWidth();

--- a/include/avt_vimba_camera/mono_camera_node.hpp
+++ b/include/avt_vimba_camera/mono_camera_node.hpp
@@ -41,8 +41,8 @@
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <camera_info_manager/camera_info_manager.hpp>
 #include <image_transport/image_transport.hpp>
+#include <std_srvs/srv/trigger.hpp>
 
-#include <string>
 
 namespace avt_vimba_camera
 {
@@ -66,9 +66,19 @@ private:
 
   image_transport::CameraPublisher camera_info_pub_;
   std::shared_ptr<camera_info_manager::CameraInfoManager> info_man_;
+  
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_srv_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stop_srv_;
+
 
   void loadParams();
   void frameCallback(const FramePtr& vimba_frame_ptr);
+  void startSrvCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                        const std_srvs::srv::Trigger::Request::SharedPtr req,
+                        std_srvs::srv::Trigger::Response::SharedPtr res);
+  void stopSrvCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                       const std_srvs::srv::Trigger::Request::SharedPtr req,
+                       std_srvs::srv::Trigger::Response::SharedPtr res);
 };
 }  // namespace avt_vimba_camera
 #endif

--- a/launch/mono_camera.launch.xml
+++ b/launch/mono_camera.launch.xml
@@ -13,7 +13,7 @@
 
   <!-- Camera parameters are used to configure the AVT camera upon startup, these params are defined in yaml files -->
   <!-- NOTE: It is suggested to create your own yaml file and use the following 'params_file' when launching -->
-  <arg name="params_file" default="$(find-pkg-share avt_vimba_camera)/config/usb_1800_U.yaml"/>
+  <arg name="params_file" default="$(find-pkg-share avt_vimba_camera)/config/params.yaml"/>
 
   <node pkg="avt_vimba_camera" exec="mono_camera_exec" name="$(var name)" output="screen">
     <param name="name" value="$(var name)"/>

--- a/launch/mono_camera.launch.xml
+++ b/launch/mono_camera.launch.xml
@@ -13,7 +13,7 @@
 
   <!-- Camera parameters are used to configure the AVT camera upon startup, these params are defined in yaml files -->
   <!-- NOTE: It is suggested to create your own yaml file and use the following 'params_file' when launching -->
-  <arg name="params_file" default="$(find-pkg-share avt_vimba_camera)/config/params.yaml"/>
+  <arg name="params_file" default="$(find-pkg-share avt_vimba_camera)/config/usb_1800_U.yaml"/>
 
   <node pkg="avt_vimba_camera" exec="mono_camera_exec" name="$(var name)" output="screen">
     <param name="name" value="$(var name)"/>

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,10 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>backward_ros</depend>
 
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>sensor_msgs</depend>
   <depend>camera_info_manager</depend>
   <depend>diagnostic_updater</depend>

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -284,7 +284,7 @@ void AvtVimbaCamera::frameCallback(const FramePtr vimba_frame_ptr)
   thread_callback.join();
 }
 
-CameraState AvtVimbaCamera::getCameraState()
+CameraState AvtVimbaCamera::getCameraState() const
 {
   return camera_state_;
 }

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -810,14 +810,13 @@ bool AvtVimbaCamera::createParamFromFeature(const FeaturePtr feature, std::strin
         feature->GetRange(minimum_value, maximum_value);
         feature->GetIncrement(step);
         
-        initial_value = std::clamp(initial_value, minimum_value, maximum_value);
+        initial_value = std::max(maximum_value, std::min(initial_value, minimum_value));
 
         rcl_interfaces::msg::FloatingPointRange float_range;
         float_range.from_value = minimum_value;
         float_range.to_value = maximum_value;
-        // TODO: setting step throws an exception rclcpp::exceptions::InvalidParameterValueException
-        // this need to be debugged
-        // float_range.step = step;
+        float_range.step = step;
+
         descriptor.floating_point_range.push_back(float_range);
         
         nh_->declare_parameter<double>(PARAM_NAMESPACE + feature_name, initial_value, descriptor);

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -815,7 +815,8 @@ bool AvtVimbaCamera::createParamFromFeature(const FeaturePtr feature, std::strin
         rcl_interfaces::msg::FloatingPointRange float_range;
         float_range.from_value = minimum_value;
         float_range.to_value = maximum_value;
-        float_range.step = step;
+        // TODO: step is not working when feature is set to Continuous
+        // float_range.step = step;
 
         descriptor.floating_point_range.push_back(float_range);
         

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -37,7 +37,6 @@
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 
 #include <signal.h>
-#include <thread>
 
 namespace avt_vimba_camera
 {
@@ -51,6 +50,7 @@ AvtVimbaCamera::AvtVimbaCamera(rclcpp::Node::SharedPtr owner_node)
   streaming_ = false;  // capturing frames
   on_init_ = true;     // on initialization phase
   on_init_config_ = false;
+  force_stopped_ = false;
   camera_state_ = OPENING;
 
   // Features that affect the camera_info parameters
@@ -282,6 +282,11 @@ void AvtVimbaCamera::frameCallback(const FramePtr vimba_frame_ptr)
   // Call the callback implemented by other classes
   std::thread thread_callback = std::thread(userFrameCallback, vimba_frame_ptr);
   thread_callback.join();
+}
+
+CameraState AvtVimbaCamera::getCameraState()
+{
+  return camera_state_;
 }
 
 double AvtVimbaCamera::getTimestamp()
@@ -784,6 +789,7 @@ bool AvtVimbaCamera::createParamFromFeature(const FeaturePtr feature, std::strin
         feature->GetValue(initial_value);
         feature->GetRange(minimum_value, maximum_value);
         feature->GetIncrement(step);
+        initial_value = std::max(minimum_value, std::min(initial_value, maximum_value));
 
         rcl_interfaces::msg::IntegerRange int_range;
         int_range.from_value = minimum_value;
@@ -803,13 +809,17 @@ bool AvtVimbaCamera::createParamFromFeature(const FeaturePtr feature, std::strin
         feature->GetValue(initial_value);
         feature->GetRange(minimum_value, maximum_value);
         feature->GetIncrement(step);
+        
+        initial_value = std::clamp(initial_value, minimum_value, maximum_value);
 
         rcl_interfaces::msg::FloatingPointRange float_range;
         float_range.from_value = minimum_value;
         float_range.to_value = maximum_value;
-        float_range.step = step;
+        // TODO: setting step throws an exception rclcpp::exceptions::InvalidParameterValueException
+        // this need to be debugged
+        // float_range.step = step;
         descriptor.floating_point_range.push_back(float_range);
-
+        
         nh_->declare_parameter<double>(PARAM_NAMESPACE + feature_name, initial_value, descriptor);
         break;
       }
@@ -871,7 +881,6 @@ AvtVimbaCamera::parameterCallback(const std::vector<rclcpp::Parameter>& paramete
     {
       if (writable_features_[feature_name])
       {
-        std::unique_lock<std::mutex> lock(config_mutex_);
 
         // Stop imaging since parameter changes can affect the image frames being received
         if (streaming_ && !on_init_config_)
@@ -880,6 +889,7 @@ AvtVimbaCamera::parameterCallback(const std::vector<rclcpp::Parameter>& paramete
           std::this_thread::sleep_for(std::chrono::milliseconds(500));
         }
 
+        std::unique_lock<std::mutex> lock(config_mutex_);
         rclcpp::ParameterType param_type = param.get_type();
 
         switch (param_type)
@@ -914,7 +924,7 @@ AvtVimbaCamera::parameterCallback(const std::vector<rclcpp::Parameter>& paramete
           updateCameraInfo();
         }
 
-        if (!on_init_config_)
+        if (!(on_init_config_ || force_stopped_))
         {
           startImaging();
         }

--- a/src/mono_camera_node.cpp
+++ b/src/mono_camera_node.cpp
@@ -118,11 +118,7 @@ void MonoCameraNode::startSrvCallback(const std::shared_ptr<rmw_request_id_t> re
   cam_.startImaging();
   cam_.setForceStop(false);
   auto state = cam_.getCameraState();
-  res->success = true;
-  if (state == CameraState::ERROR)
-  {
-    res->success = false;
-  }
+  res->success = state != CameraState::ERROR;
 }
 
 void MonoCameraNode::stopSrvCallback(const std::shared_ptr<rmw_request_id_t> request_header,
@@ -135,11 +131,7 @@ void MonoCameraNode::stopSrvCallback(const std::shared_ptr<rmw_request_id_t> req
   cam_.stopImaging();
   cam_.setForceStop(true);
   auto state = cam_.getCameraState();
-  res->success = true;
-  if (state == CameraState::ERROR)
-  {
-    res->success = false;
-  }
+  res->success = state != CameraState::ERROR;
 }
 
 }  // namespace avt_vimba_camera

--- a/src/mono_camera_node.cpp
+++ b/src/mono_camera_node.cpp
@@ -32,6 +32,8 @@
 
 #include "avt_vimba_camera/mono_camera_node.hpp"
 
+using namespace std::placeholders;
+
 namespace avt_vimba_camera
 {
 MonoCameraNode::MonoCameraNode() : Node("camera"), api_(this->get_logger()), cam_(std::shared_ptr<rclcpp::Node>(dynamic_cast<rclcpp::Node * >(this)))
@@ -40,7 +42,10 @@ MonoCameraNode::MonoCameraNode() : Node("camera"), api_(this->get_logger()), cam
   camera_info_pub_ = image_transport::create_camera_publisher(this, "~/image", rmw_qos_profile_system_default);
 
   // Set the frame callback
-  cam_.setCallback(std::bind(&avt_vimba_camera::MonoCameraNode::frameCallback, this, std::placeholders::_1));
+  cam_.setCallback(std::bind(&avt_vimba_camera::MonoCameraNode::frameCallback, this, _1));
+
+  start_srv_ = create_service<std_srvs::srv::Trigger>("start_stream", std::bind(&MonoCameraNode::startSrvCallback, this, _1, _2, _3));
+  stop_srv_ = create_service<std_srvs::srv::Trigger>("stop_stream", std::bind(&MonoCameraNode::stopSrvCallback, this, _1, _2, _3));
 
   loadParams();
 }
@@ -101,6 +106,39 @@ void MonoCameraNode::frameCallback(const FramePtr& vimba_frame_ptr)
     {
       RCLCPP_WARN_STREAM(this->get_logger(), "Function frameToImage returned 0. No image published.");
     }
+  }
+}
+
+void MonoCameraNode::startSrvCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                      const std_srvs::srv::Trigger::Request::SharedPtr req,
+                                      std_srvs::srv::Trigger::Response::SharedPtr res) {
+  (void)request_header;
+  (void)req;
+
+  cam_.startImaging();
+  cam_.setForceStop(false);
+  auto state = cam_.getCameraState();
+  res->success = true;
+  if (state == CameraState::ERROR)
+  {
+    res->success = false;
+  }
+}
+
+void MonoCameraNode::stopSrvCallback(const std::shared_ptr<rmw_request_id_t> request_header,
+                                     const std_srvs::srv::Trigger::Request::SharedPtr req,
+                                     std_srvs::srv::Trigger::Response::SharedPtr res)
+{
+  (void)request_header;
+  (void)req;
+
+  cam_.stopImaging();
+  cam_.setForceStop(true);
+  auto state = cam_.getCameraState();
+  res->success = true;
+  if (state == CameraState::ERROR)
+  {
+    res->success = false;
   }
 }
 

--- a/src/mono_camera_node.cpp
+++ b/src/mono_camera_node.cpp
@@ -44,8 +44,8 @@ MonoCameraNode::MonoCameraNode() : Node("camera"), api_(this->get_logger()), cam
   // Set the frame callback
   cam_.setCallback(std::bind(&avt_vimba_camera::MonoCameraNode::frameCallback, this, _1));
 
-  start_srv_ = create_service<std_srvs::srv::Trigger>("start_stream", std::bind(&MonoCameraNode::startSrvCallback, this, _1, _2, _3));
-  stop_srv_ = create_service<std_srvs::srv::Trigger>("stop_stream", std::bind(&MonoCameraNode::stopSrvCallback, this, _1, _2, _3));
+  start_srv_ = create_service<std_srvs::srv::Trigger>("~/start_stream", std::bind(&MonoCameraNode::startSrvCallback, this, _1, _2, _3));
+  stop_srv_ = create_service<std_srvs::srv::Trigger>("~/stop_stream", std::bind(&MonoCameraNode::stopSrvCallback, this, _1, _2, _3));
 
   loadParams();
 }


### PR DESCRIPTION
In this PR I have made the following changes:
* added start and stop streaming services (unfortunately lifecycle node currently doesn't support ImageTransport)
* fixed a bug with parameter server (mutex before stopImagaing() causes a dead lock)
* added a example config for USB cameras

Also, I have tested this PR on foxy and galactic.