### PR TITLE
Nodelet parameter namespace

### DIFF
--- a/include/avt_vimba_camera/mono_camera.h
+++ b/include/avt_vimba_camera/mono_camera.h
@@ -77,7 +77,7 @@ private:
   // Dynamic reconfigure
   typedef avt_vimba_camera::AvtVimbaCameraConfig Config;
   typedef dynamic_reconfigure::Server<Config> ReconfigureServer;
-  ReconfigureServer reconfigure_server_;
+  ReconfigureServer reconfigure_server_{nhp_};
 
   // Camera configuration
   Config camera_config_;

--- a/launch/mono_camera_nodelet.launch
+++ b/launch/mono_camera_nodelet.launch
@@ -80,7 +80,7 @@
 
   <!-- Image processing -->
   <include if="$(arg image_proc)" ns="$(arg name)" file="$(find image_proc)/launch/image_proc.launch">
-    <arg name="manager" value="avt_vimba_nodelet_manager"/>
+    <arg name="manager" value="/avt_vimba_nodelet_manager"/>
   </include>
 
   <!-- The mono camera nodelet -->


### PR DESCRIPTION
I think this should solve #94 .

`image_proc` needs the manager arg globally.

> manager (string)
>     The name of the target nodelet manager. It will need to be globally qualified (e.g. /my_manager), unless the manager is already in the camera namespace.

Further I found here the hint to provide the reconfiguration server with the node handle as well.
[https://answers.ros.org/.../multiple-instances-of-a-dynamic_reconfigure-server-in-the-same-client-node/](https://answers.ros.org/question/289040/multiple-instances-of-a-dynamic_reconfigure-server-in-the-same-client-node/)