### PR TITLE
Fix DeviceTemperatureSelector

### DIFF
--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -319,7 +319,7 @@ double AvtVimbaCamera::getTimestamp()
 double AvtVimbaCamera::getDeviceTemp()
 {
   double temp = -1.0;
-  if (setFeatureValue("DeviceTemperatureSelector", "MainBoard") == VmbErrorSuccess)
+  if (setFeatureValue("DeviceTemperatureSelector", "Mainboard") == VmbErrorSuccess)
   {
     getFeatureValue("DeviceTemperature", temp);
   }

--- a/src/avt_vimba_camera.cpp
+++ b/src/avt_vimba_camera.cpp
@@ -319,7 +319,7 @@ double AvtVimbaCamera::getTimestamp()
 double AvtVimbaCamera::getDeviceTemp()
 {
   double temp = -1.0;
-  if (setFeatureValue("DeviceTemperatureSelector", "Main") == VmbErrorSuccess)
+  if (setFeatureValue("DeviceTemperatureSelector", "MainBoard") == VmbErrorSuccess)
   {
     getFeatureValue("DeviceTemperature", temp);
   }


### PR DESCRIPTION
In the [Alvium Features Reference V2.9.1](https://cdn.alliedvision.com/fileadmin/content/documents/products/cameras/various/features/Alvium_Features_Reference.pdf) they show the available options for the `DeviceTemperatureSelector` are:
- _Mainboard_
- _FpgaCore_ (only for G5)
- _PhyCore_ (only for G5)

I've changed the value in your code to `Mainboard`

If you don't do that, a warning message appears each 1-2 seconds when connected to the device.  It also seems to fix #119 .
